### PR TITLE
[cmake] rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 
 if(WIN32)
   add_definitions(-DDIRECTX_SPEKTRUM_EXPORTS -D_WIN32PC -D_USRDLL)

--- a/visualization.spectrum/addon.xml.in
+++ b/visualization.spectrum/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.spectrum"
-  version="1.0.14"
+  version="1.1.0"
   name="Spectrum"
   provider-name="Team XBMC">
   <extension


### PR DESCRIPTION
Package renaming is needed after https://github.com/xbmc/xbmc/pull/9750 goes in.