### PR TITLE
fix OpenGL ES 2.0 compile

### DIFF
--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -153,26 +153,14 @@ CVisualizationSpectrum::CVisualizationSpectrum()
 
 #if defined(HAS_GLES2)
   m_visShader = new CVisGUIShader(vert, frag);
-
-  if(!m_visShader)
-    return ADDON_STATUS_UNKNOWN;
-
-  if(!m_visShader->CompileAndLink())
-  {
-    delete m_visShader;
-    return ADDON_STATUS_UNKNOWN;
-  }
 #endif
 }
 
 CVisualizationSpectrum::~CVisualizationSpectrum()
 {
 #if defined(HAS_GLES2)
-  if(m_visShader) 
-  {
-    m_visShader->Free();
-    delete m_visShader;
-  }
+  m_visShader->Free();
+  delete m_visShader;
 #endif
 }
 
@@ -376,6 +364,14 @@ void CVisualizationSpectrum::Render()
 
 bool CVisualizationSpectrum::Start(int iChannels, int iSamplesPerSec, int iBitsPerSample, std::string szSongName)
 {
+#if defined(HAS_GLES2)
+  if (!m_visShader->CompileAndLink())
+  {
+    kodi::Log(ADDON_LOG_ERROR, "Failed to create Open GL ES 2.0 visualization GUI shader");
+    return false;
+  }
+#endif
+
   int x, y;
 
   for(x = 0; x < 16; x++)

--- a/visualization.spectrum/addon.xml.in
+++ b/visualization.spectrum/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.spectrum"
-  version="2.0.0"
+  version="2.0.1"
   name="Spectrum"
   provider-name="Team XBMC">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This is a fix for my wrongly forgotten OpenGL ES 2.0. Have testet and compile is now OK, but the "ES" was not usable on my system and has returned with `CompileAndLink()` false.