### PR TITLE
[Backport] Add missing cstddef include

### DIFF
--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include <cstddef>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>


### PR DESCRIPTION
Backported from https://github.com/xbmc/visualization.spectrum/pull/37