### PR TITLE
Add missing cstddef include

### DIFF
--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include <cstddef>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>


### PR DESCRIPTION
Fixes build error with gcc 5.5.0

Cherry-picked from
https://github.com/xbmc/visualization.spectrum/commit/b2c54c1043c2396678005b578e85db30bdf5ccb9