### PR TITLE
Fix uninitialized fields

### DIFF
--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -357,6 +357,7 @@ bool CVisualizationSpectrum::Start(int iChannels, int iSamplesPerSec, int iBitsP
     for(y = 0; y < 16; y++)
     {
       m_cHeights[y][x] = 0.0;
+      m_heights[y][x] = 0.0;
     }
   }
 

--- a/src/shaders/Shader.cpp
+++ b/src/shaders/Shader.cpp
@@ -30,7 +30,7 @@
 //////////////////////////////////////////////////////////////////////
 bool CShader::LoadSource(std::string &file)
 {
-  char buffer[1024];
+  char buffer[1024] = { 0 };
 
   kodi::vfs::CFile source;
   source.OpenFile(file);


### PR DESCRIPTION
This patch fixes the following issues detected by valgrind:
==1041== Thread 1:
==1041== Conditional jump or move depends on uninitialised value(s)
==1041==    at 0x1E7D723B: UnknownInlinedFun (char_traits.h:322)
==1041==    by 0x1E7D723B: UnknownInlinedFun (basic_string.h:1439)
==1041==    by 0x1E7D723B: CShader::LoadSource(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (Shader.cpp:38)
==1041==    by 0x1E7DB71C: UnknownInlinedFun (Shader.cpp:156)
==1041==    by 0x1E7DB71C: CGUIShader::CGUIShader(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (GUIShader.cpp:23)
==1041==    by 0x1E7DBF46: UnknownInlinedFun (opengl_spectrum.cpp:108)
==1041==    by 0x1E7DBF46: ADDON_Create (opengl_spectrum.cpp:511)
==1041==    by 0xF1CB17: CreateEx (DllAddon.h:33)
==1041==    by 0xF1CB17: ADDON::CAddonDll::Create(void*) (AddonDll.cpp:270)
==1041==    by 0xF1CEB1: ADDON::CAddonDll::CreateInstance(ADDON_TYPE, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, void*) (AddonDll.cpp:323)
==1041==    by 0xF23D8F: ADDON::IAddonInstanceHandler::CreateInstance(void*) (AddonInstanceHandler.cpp:83)
==1041==    by 0xFC7561: ADDON::CVisualization::CVisualization(std::shared_ptr<ADDON::CBinaryAddonBase>, float, float, float, float) (Visualization.cpp:47)
==1041==    by 0xE43C1F: CGUIVisualisationControl::InitVisualization() (GUIVisualisationControl.cpp:394)
==1041==    by 0xE44B20: CGUIVisualisationControl::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIVisualisationControl.cpp:157)
==1041==    by 0xDE394A: CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControl.cpp:134)
==1041==    by 0xDF00CF: CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControlGroup.cpp:92)
==1041==    by 0xDE394A: CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControl.cpp:134)
==1041==  Uninitialised value was created by a stack allocation
==1041==    at 0x1E7D71C0: CShader::LoadSource(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (Shader.cpp:32)


==5143== Conditional jump or move depends on uninitialised value(s)
==5143==    at 0xFD3BD49: UnknownInlinedFun (opengl_spectrum.cpp:294)
==5143==    by 0xFD3BD49: CVisualizationSpectrum::Render() (opengl_spectrum.cpp:337)
==5143==    by 0xE42EDF: Render (GUIVisualisationControl.cpp:210)
==5143==    by 0xE42EDF: CGUIVisualisationControl::Render() (GUIVisualisationControl.cpp:199)
==5143==    by 0xDE1454: DoRender (GUIControl.cpp:191)
==5143==    by 0xDE1454: CGUIControl::DoRender() (GUIControl.cpp:169)
==5143==    by 0xDEFDED: CGUIControlGroup::Render() (GUIControlGroup.cpp:112)
==5143==    by 0xDE1454: DoRender (GUIControl.cpp:191)
==5143==    by 0xDE1454: CGUIControl::DoRender() (GUIControl.cpp:169)
==5143==    by 0xE4962B: CGUIWindow::DoRender() (GUIWindow.cpp:354)
==5143==    by 0xE4DBBF: CGUIWindowManager::RenderPass() const (GUIWindowManager.cpp:1144)
==5143==    by 0xE4DF53: CGUIWindowManager::Render() (GUIWindowManager.cpp:1194)
==5143==    by 0xFC94B4: Render (Application.cpp:1551)
==5143==    by 0xFC94B4: CApplication::Render() (Application.cpp:1515)
==5143==    by 0xE4B3E4: CGUIWindowManager::ProcessRenderLoop(bool) (GUIWindowManager.cpp:1310)
==5143==    by 0xDF5EC6: CGUIDialog::Open_Internal(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIDialog.cpp:201)
==5143==    by 0xDF6025: CGUIDialog::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIDialog.cpp:216)
==5143==  Uninitialised value was created by a heap allocation
==5143==    at 0x4837E62: operator new(unsigned long) (in /usr/local/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==5143==    by 0xFD3CC21: ADDON_Create (opengl_spectrum.cpp:511)
==5143==    by 0xF1CB17: CreateEx (DllAddon.h:33)
==5143==    by 0xF1CB17: ADDON::CAddonDll::Create(void*) (AddonDll.cpp:270)
==5143==    by 0xF1CEB1: ADDON::CAddonDll::CreateInstance(ADDON_TYPE, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, void*) (AddonDll.cpp:323)
==5143==    by 0xF23D8F: ADDON::IAddonInstanceHandler::CreateInstance(void*) (AddonInstanceHandler.cpp:83)
==5143==    by 0xFC7561: ADDON::CVisualization::CVisualization(std::shared_ptr<ADDON::CBinaryAddonBase>, float, float, float, float) (Visualization.cpp:47)
==5143==    by 0xE43C1F: CGUIVisualisationControl::InitVisualization() (GUIVisualisationControl.cpp:394)
==5143==    by 0xE44B20: CGUIVisualisationControl::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIVisualisationControl.cpp:157)
==5143==    by 0xDE394A: CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControl.cpp:134)
==5143==    by 0xDF00CF: CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControlGroup.cpp:92)
==5143==    by 0xDE394A: CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIControl.cpp:134)
==5143==    by 0xE494E9: CGUIWindow::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion> >&) (GUIWindow.cpp:333)