### PR TITLE
[Matrix|N*] copyright year increase, language string fix and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/visualization.spectrum.svg?branch=Matrix)](https://travis-ci.org/xbmc/visualization.spectrum/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.spectrum?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=33&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.spectrum/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.spectrum/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.spectrum?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-spectrum?branch=Matrix) -->

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: visualization.spectrum
 
 Files: *
 Copyright: 1998-2000  Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies 
-           2005-2020 Team Kodi
+           2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ License: GPL-2+
 Files: debian/*
 Copyright: 2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
            2013 wsnipex <wsnipex@a1.net>
-           2005-2020 Team Kodi
+           2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/DefaultPixelShader.hlsl
+++ b/src/DefaultPixelShader.hlsl
@@ -1,24 +1,11 @@
 /*
-*      Copyright (C) 2005-2021 Team Kodi
-*      http://kodi.tv
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with Kodi; see the file COPYING.  If not, see
-*  <http://www.gnu.org/licenses/>.
-*
-*/
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
 
 float4 main(float4 pos: SV_POSITION, float4 col : COLOR) : SV_TARGET
 {
-	return col;
+  return col;
 }

--- a/src/DefaultPixelShader.hlsl
+++ b/src/DefaultPixelShader.hlsl
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2005-2020 Team Kodi
+*      Copyright (C) 2005-2021 Team Kodi
 *      http://kodi.tv
 *
 *  This Program is free software; you can redistribute it and/or modify

--- a/src/DefaultVertexShader.hlsl
+++ b/src/DefaultVertexShader.hlsl
@@ -1,22 +1,9 @@
 /*
-*      Copyright (C) 2005-2021 Team Kodi
-*      http://kodi.tv
-*
-*  This Program is free software; you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation; either version 2, or (at your option)
-*  any later version.
-*
-*  This Program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with Kodi; see the file COPYING.  If not, see
-*  <http://www.gnu.org/licenses/>.
-*
-*/
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
 
 struct VS_OUT
 {

--- a/src/DefaultVertexShader.hlsl
+++ b/src/DefaultVertexShader.hlsl
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2005-2020 Team Kodi
+*      Copyright (C) 2005-2021 Team Kodi
 *      http://kodi.tv
 *
 *  This Program is free software; you can redistribute it and/or modify

--- a/src/directx_spectrum.cpp
+++ b/src/directx_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1998-2000 Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1998-2000 Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/visualization.spectrum/resources/language/resource.language.en_gb/strings.po
+++ b/visualization.spectrum/resources/language/resource.language.en_gb/strings.po
@@ -83,7 +83,7 @@ msgid "Point size"
 msgstr ""
 
 msgctxt "#30016"
-msgid "%i pixel"
+msgid "{0:d} pixel"
 msgstr ""
 
 msgctxt "#30017"
@@ -91,7 +91,7 @@ msgid "Rotation position"
 msgstr ""
 
 msgctxt "#30018"
-msgid "%i°"
+msgid "{0:d}°"
 msgstr ""
 
 msgctxt "#30019"


### PR DESCRIPTION
- set copyright year to 2021
- update hlsl shader code copyright to SPDX format
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com
- fix language string with integer format number

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.

After this comes new branch for Nexus two separate requests with version increases.