### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This is a [Kodi](https://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.spectrum?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=33&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.spectrum/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.spectrum/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.spectrum?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-spectrum?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.spectrum?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=33&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.spectrum/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.spectrum/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.spectrum?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-spectrum?branch=Nexus) -->
 
-![screenshot](https://raw.githubusercontent.com/xbmc/visualization.spectrum/Matrix/visualization.spectrum/resources/screenshot-01.jpg)
+![screenshot](https://raw.githubusercontent.com/xbmc/visualization.spectrum/Nexus/visualization.spectrum/resources/screenshot-01.jpg)
 
 ## Build instructions
 
@@ -21,7 +21,7 @@ The following instructions assume you will have built Kodi already in the `kodi-
 suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/visualization.spectrum.git`
+2. `git clone --branch Nexus https://github.com/xbmc/visualization.spectrum.git`
 3. `cd visualization.spectrum && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=visualization.spectrum -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/visualization.spectrum/addon.xml.in
+++ b/visualization.spectrum/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.spectrum"
-  version="3.4.0"
+  version="20.0.0"
   name="Spectrum"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.