### PR TITLE
update to visualization API 5.0.0 and code cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^<[a-z0-9_]+>$'
+    Priority:        3
+  - Regex:           '^<(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        3
+  - Regex:           '^["<](kodi|p8-platform)\/.*\.h[">]$'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60000
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 project(visualization.spectrum)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,8 +2,8 @@ Format: http://dep.debian.net/deps/dep5
 Upstream-Name: visualization.spectrum
 
 Files: *
-Copyright: 1998-2000  Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies 
-           2005-2022 Team Kodi
+Copyright: 1998-2000  Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
+           2005-2026 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ License: GPL-2+
 Files: debian/*
 Copyright: 2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
            2013 wsnipex <wsnipex@a1.net>
-           2005-2022 Team Kodi
+           2005-2026 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/DefaultPixelShader.hlsl
+++ b/src/DefaultPixelShader.hlsl
@@ -5,7 +5,7 @@
  *  See LICENSE.md for more information.
  */
 
-float4 main(float4 pos: SV_POSITION, float4 col : COLOR) : SV_TARGET
+float4 main(float4 pos : SV_POSITION, float4 col : COLOR) : SV_TARGET
 {
   return col;
 }

--- a/src/DefaultVertexShader.hlsl
+++ b/src/DefaultVertexShader.hlsl
@@ -25,7 +25,7 @@ cbuffer cbWorld : register(b1)
 VS_OUT main(float4 pos : POSITION, float4 col : COLOR)
 {
   VS_OUT r = (VS_OUT)0;
-  r.pos = mul(  pos, world);
+  r.pos = mul(pos, world);
   r.pos = mul(r.pos, view);
   r.pos = mul(r.pos, proj);
   r.col = col;

--- a/src/directx_spectrum.cpp
+++ b/src/directx_spectrum.cpp
@@ -60,8 +60,11 @@ class CVisualizationSpectrum : public kodi::addon::CAddonBase,
                                public kodi::addon::CInstanceVisualization
 {
 public:
-  CVisualizationSpectrum();
-  ~CVisualizationSpectrum() override;
+  CVisualizationSpectrum() = default;
+  ~CVisualizationSpectrum() override = default;
+
+  bool Init() override;
+  void DeInit() override;
 
   void Render() override;
   void AudioData(const float* audioData, size_t audioDataLength) override;
@@ -111,7 +114,7 @@ private:
 // Called on load. Addon should fully initalize or return error status
 // !!! Add-on master function !!!
 //-----------------------------------------------------------------------------
-CVisualizationSpectrum::CVisualizationSpectrum()
+bool CVisualizationSpectrum::Init()
 {
   m_context = (ID3D11DeviceContext*)Device();
   m_context->GetDevice(&m_device);
@@ -122,14 +125,18 @@ CVisualizationSpectrum::CVisualizationSpectrum()
   m_y_fixedAngle = kodi::addon::GetSettingInt("rotation_angle");
 
   if (!init_renderer_objs())
+  {
     kodi::Log(ADDON_LOG_ERROR, "Failed to init DirectX");
+    return false;
+  }
+
+  return true;
 }
 
-//-- Destroy ------------------------------------------------------------------
+//-- DeInit ------------------------------------------------------------------
 // Do everything before unload of this add-on
-// !!! Add-on master function !!!
 //-----------------------------------------------------------------------------
-CVisualizationSpectrum::~CVisualizationSpectrum()
+void CVisualizationSpectrum::DeInit()
 {
   if (m_cViewProj)
     m_cViewProj->Release();

--- a/src/directx_spectrum.cpp
+++ b/src/directx_spectrum.cpp
@@ -63,10 +63,6 @@ public:
   CVisualizationSpectrum();
   ~CVisualizationSpectrum() override;
 
-  bool Start(int channels,
-             int samplesPerSec,
-             int bitsPerSample,
-             const std::string& songName) override;
   void Render() override;
   void AudioData(const float* audioData, size_t audioDataLength) override;
   ADDON_STATUS SetSetting(const std::string& settingName,
@@ -77,12 +73,18 @@ private:
   void SetSpeedSetting(int settingValue);
   void SetModeSetting(int settingValue);
 
-  float heights[16][16], cHeights[16][16], m_scale;
-  DWORD m_mode; // D3DFILL_SOLID;
-  float m_y_angle, m_y_speed, m_y_fixedAngle;
-  float m_x_angle, m_x_speed;
-  float m_z_angle, m_z_speed;
-  float m_hSpeed;
+  float heights[16][16] = {0.0f};
+  float cHeights[16][16] = {0.0f};
+  float m_scale{1.0f / log(256.0f)};
+  DWORD m_mode{3}; // D3DFILL_SOLID;
+  float m_y_angle{45.0f};
+  float m_y_speed{0.5f};
+  float m_y_fixedAngle{0.0f};
+  float m_x_angle{20.0f};
+  float m_x_speed{0.0f};
+  float m_z_angle{0.0f};
+  float m_z_speed{0.0f};
+  float m_hSpeed{0.05f};
 
   void draw_vertex(Vertex_t* pVertex, float x, float y, float z, XMFLOAT4 color);
   int draw_rectangle(
@@ -91,18 +93,18 @@ private:
   void draw_bars(void);
   bool init_renderer_objs();
 
-  ID3D11Device* m_device = nullptr;
-  ID3D11DeviceContext* m_context = nullptr;
-  ID3D11VertexShader* m_vShader = nullptr;
-  ID3D11PixelShader* m_pShader = nullptr;
-  ID3D11InputLayout* m_inputLayout = nullptr;
-  ID3D11Buffer* m_vBuffer = nullptr;
-  ID3D11Buffer* m_cViewProj = nullptr;
-  ID3D11Buffer* m_cWorld = nullptr;
-  ID3D11RasterizerState* m_rsStateSolid = nullptr;
-  ID3D11RasterizerState* m_rsStateWire = nullptr;
-  ID3D11BlendState* m_omBlend = nullptr;
-  ID3D11DepthStencilState* m_omDepth = nullptr;
+  ID3D11Device* m_device{nullptr};
+  ID3D11DeviceContext* m_context{nullptr};
+  ID3D11VertexShader* m_vShader{nullptr};
+  ID3D11PixelShader* m_pShader{nullptr};
+  ID3D11InputLayout* m_inputLayout{nullptr};
+  ID3D11Buffer* m_vBuffer{nullptr};
+  ID3D11Buffer* m_cViewProj{nullptr};
+  ID3D11Buffer* m_cWorld{nullptr};
+  ID3D11RasterizerState* m_rsStateSolid{nullptr};
+  ID3D11RasterizerState* m_rsStateWire{nullptr};
+  ID3D11BlendState* m_omBlend{nullptr};
+  ID3D11DepthStencilState* m_omDepth{nullptr};
 };
 
 //-- Create -------------------------------------------------------------------
@@ -110,14 +112,6 @@ private:
 // !!! Add-on master function !!!
 //-----------------------------------------------------------------------------
 CVisualizationSpectrum::CVisualizationSpectrum()
-  : m_mode(3),
-    m_y_angle(45.0f),
-    m_y_speed(0.5f),
-    m_x_angle(20.0f),
-    m_x_speed(0.0f),
-    m_z_angle(0.0f),
-    m_z_speed(0.0f),
-    m_hSpeed(0.05f)
 {
   m_context = (ID3D11DeviceContext*)Device();
   m_context->GetDevice(&m_device);
@@ -228,34 +222,6 @@ void CVisualizationSpectrum::Render()
 
     draw_bars();
   }
-}
-
-bool CVisualizationSpectrum::Start(int iChannels,
-                                   int iSamplesPerSec,
-                                   int iBitsPerSample,
-                                   const std::string& songName)
-{
-  int x, y;
-
-  for (x = 0; x < 16; x++)
-  {
-    for (y = 0; y < 16; y++)
-    {
-      heights[y][x] = 0.0f;
-      cHeights[y][x] = 0.0f;
-    }
-  }
-
-  m_scale = 1.0f / log(256.0f);
-
-  m_x_speed = 0.0f;
-  m_y_speed = 0.5f;
-  m_z_speed = 0.0f;
-  m_x_angle = 20.0f;
-  m_y_angle = 45.0f;
-  m_z_angle = 0.0f;
-
-  return true;
 }
 
 void CVisualizationSpectrum::AudioData(const float* pAudioData, size_t audioDataLength)

--- a/src/directx_spectrum.cpp
+++ b/src/directx_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1998-2000 Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
- *  Copyright (C) 2005-2022 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2026 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/directx_spectrum.cpp
+++ b/src/directx_spectrum.cpp
@@ -17,11 +17,11 @@
  *  Also added 'm_hSpeed' to animate transition between bar heights
  */
 
-#include <kodi/addon-instance/Visualization.h>
-#include <math.h>
-#include <d3d11_1.h>
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
+#include <d3d11_1.h>
+#include <kodi/addon-instance/Visualization.h>
+#include <math.h>
 #include <stdio.h>
 
 #define NUM_BANDS 16
@@ -33,9 +33,9 @@ using namespace DirectX::PackedVector;
 // Include the precompiled shader code.
 namespace
 {
-  #include "DefaultPixelShader.inc"
-  #include "DefaultVertexShader.inc"
-}
+#include "DefaultPixelShader.inc"
+#include "DefaultVertexShader.inc"
+} // namespace
 
 typedef struct
 {
@@ -56,18 +56,21 @@ typedef struct
 
 #define VERTEX_FORMAT (D3DFVF_XYZ | D3DFVF_DIFFUSE)
 
-class CVisualizationSpectrum
-  : public kodi::addon::CAddonBase,
-    public kodi::addon::CInstanceVisualization
+class CVisualizationSpectrum : public kodi::addon::CAddonBase,
+                               public kodi::addon::CInstanceVisualization
 {
 public:
   CVisualizationSpectrum();
   ~CVisualizationSpectrum() override;
 
-  bool Start(int channels, int samplesPerSec, int bitsPerSample, const std::string& songName) override;
+  bool Start(int channels,
+             int samplesPerSec,
+             int bitsPerSample,
+             const std::string& songName) override;
   void Render() override;
   void AudioData(const float* audioData, size_t audioDataLength) override;
-  ADDON_STATUS SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue) override;
+  ADDON_STATUS SetSetting(const std::string& settingName,
+                          const kodi::addon::CSettingValue& settingValue) override;
 
 private:
   void SetBarHeightSetting(int settingValue);
@@ -81,8 +84,9 @@ private:
   float m_z_angle, m_z_speed;
   float m_hSpeed;
 
-  void draw_vertex(Vertex_t * pVertex, float x, float y, float z, XMFLOAT4 color);
-  int draw_rectangle(Vertex_t * verts, float x1, float y1, float z1, float x2, float y2, float z2, XMFLOAT4 color);
+  void draw_vertex(Vertex_t* pVertex, float x, float y, float z, XMFLOAT4 color);
+  int draw_rectangle(
+      Vertex_t* verts, float x1, float y1, float z1, float x2, float y2, float z2, XMFLOAT4 color);
   void draw_bar(float x_offset, float z_offset, float height, float red, float green, float blue);
   void draw_bars(void);
   bool init_renderer_objs();
@@ -164,18 +168,18 @@ void CVisualizationSpectrum::Render()
 {
   bool configured = true; //FALSE;
 
-  float factors[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+  float factors[4] = {1.0f, 1.0f, 1.0f, 1.0f};
   m_context->OMSetBlendState(m_omBlend, factors, 0xFFFFFFFF);
   m_context->OMSetDepthStencilState(m_omDepth, 0);
   switch (m_mode)
   {
-  case 1: // D3DFILL_POINT:
-  case 2: // D3DFILL_WIREFRAME:
-    m_context->RSSetState(m_rsStateWire);
-    break;
-  case 3: // D3DFILL_SOLID:
-    m_context->RSSetState(m_rsStateSolid);
-    break;
+    case 1: // D3DFILL_POINT:
+    case 2: // D3DFILL_WIREFRAME:
+      m_context->RSSetState(m_rsStateWire);
+      break;
+    case 3: // D3DFILL_SOLID:
+      m_context->RSSetState(m_rsStateSolid);
+      break;
   }
 
   unsigned stride = sizeof(Vertex_t), offset = 0;
@@ -186,7 +190,7 @@ void CVisualizationSpectrum::Render()
   m_context->VSSetConstantBuffers(1, 1, &m_cWorld);
   m_context->PSSetShader(m_pShader, 0, 0);
 
-  if(configured)
+  if (configured)
   {
     m_x_angle += m_x_speed;
     if (m_x_angle >= 360.0f)
@@ -195,7 +199,7 @@ void CVisualizationSpectrum::Render()
     if (m_y_fixedAngle < 0.0f)
     {
       m_y_angle += m_y_speed;
-      if(m_y_angle >= 360.0)
+      if (m_y_angle >= 360.0)
         m_y_angle -= 360.0;
     }
     else
@@ -210,13 +214,13 @@ void CVisualizationSpectrum::Render()
     D3D11_MAPPED_SUBRESOURCE res;
     if (S_OK == m_context->Map(m_cWorld, 0, D3D11_MAP_WRITE_DISCARD, 0, &res))
     {
-      cbWorld *cWorld = (cbWorld*)res.pData;
+      cbWorld* cWorld = (cbWorld*)res.pData;
       XMMATRIX
-        matRotationX = XMMatrixRotationX(-XMConvertToRadians(m_x_angle)),
-        matRotationY = XMMatrixRotationY(-XMConvertToRadians(m_y_angle)),
-        matRotationZ = XMMatrixRotationZ(XMConvertToRadians(m_z_angle)),
-        matTranslation = XMMatrixTranslation(0.0f, -0.5f, 5.0f),
-        matWorld = matRotationZ * matRotationY * matRotationX * matTranslation;
+      matRotationX = XMMatrixRotationX(-XMConvertToRadians(m_x_angle)),
+      matRotationY = XMMatrixRotationY(-XMConvertToRadians(m_y_angle)),
+      matRotationZ = XMMatrixRotationZ(XMConvertToRadians(m_z_angle)),
+      matTranslation = XMMatrixTranslation(0.0f, -0.5f, 5.0f),
+      matWorld = matRotationZ * matRotationY * matRotationX * matTranslation;
       XMStoreFloat4x4(&cWorld->world, XMMatrixTranspose(matWorld));
 
       m_context->Unmap(m_cWorld, 0);
@@ -226,13 +230,16 @@ void CVisualizationSpectrum::Render()
   }
 }
 
-bool CVisualizationSpectrum::Start(int iChannels, int iSamplesPerSec, int iBitsPerSample, const std::string& songName)
+bool CVisualizationSpectrum::Start(int iChannels,
+                                   int iSamplesPerSec,
+                                   int iBitsPerSample,
+                                   const std::string& songName)
 {
   int x, y;
 
-  for(x = 0; x < 16; x++)
+  for (x = 0; x < 16; x++)
   {
-    for(y = 0; y < 16; y++)
+    for (y = 0; y < 16; y++)
     {
       heights[y][x] = 0.0f;
       cHeights[y][x] = 0.0f;
@@ -253,34 +260,34 @@ bool CVisualizationSpectrum::Start(int iChannels, int iSamplesPerSec, int iBitsP
 
 void CVisualizationSpectrum::AudioData(const float* pAudioData, size_t audioDataLength)
 {
-  int i,c;
-  int y=0;
+  int i, c;
+  int y = 0;
   float val;
 
   int xscale[] = {0, 1, 2, 3, 5, 7, 10, 14, 20, 28, 40, 54, 74, 101, 137, 187, 255};
 
-  for(y = 15; y > 0; y--)
+  for (y = 15; y > 0; y--)
   {
-    for(i = 0; i < 16; i++)
+    for (i = 0; i < 16; i++)
     {
       heights[y][i] = heights[y - 1][i];
     }
   }
 
-  for(i = 0; i < NUM_BANDS; i++)
+  for (i = 0; i < NUM_BANDS; i++)
   {
-    for(c = xscale[i], y = 0; c < xscale[i + 1]; c++)
+    for (c = xscale[i], y = 0; c < xscale[i + 1]; c++)
     {
       if (c < audioDataLength)
       {
-        if((int)(pAudioData[c] * (0x07fff+.5f) > y))
-          y = (int)(pAudioData[c] * (0x07fff+.5f));
+        if ((int)(pAudioData[c] * (0x07fff + .5f) > y))
+          y = (int)(pAudioData[c] * (0x07fff + .5f));
       }
       else
         continue;
     }
     y >>= 7;
-    if(y > 0)
+    if (y > 0)
       val = (logf((float)y) * m_scale);
     else
       val = 0;
@@ -292,26 +299,26 @@ void CVisualizationSpectrum::SetBarHeightSetting(int settingValue)
 {
   switch (settingValue)
   {
-  case 1://standard
-    m_scale = 1.f / log(256.f);
-    break;
+    case 1: //standard
+      m_scale = 1.f / log(256.f);
+      break;
 
-  case 2://big
-    m_scale = 2.f / log(256.f);
-    break;
+    case 2: //big
+      m_scale = 2.f / log(256.f);
+      break;
 
-  case 3://real big
-    m_scale = 3.f / log(256.f);
-    break;
+    case 3: //real big
+      m_scale = 3.f / log(256.f);
+      break;
 
-  case 4://unused
-    m_scale = 0.33f / log(256.f);
-    break;
+    case 4: //unused
+      m_scale = 0.33f / log(256.f);
+      break;
 
-  case 0://small
-  default:
-    m_scale = 0.5f / log(256.f);
-    break;
+    case 0: //small
+    default:
+      m_scale = 0.5f / log(256.f);
+      break;
   }
 }
 
@@ -319,26 +326,26 @@ void CVisualizationSpectrum::SetSpeedSetting(int settingValue)
 {
   switch (settingValue)
   {
-  case 1:
-    m_hSpeed = 0.025f;
-    break;
+    case 1:
+      m_hSpeed = 0.025f;
+      break;
 
-  case 2:
-    m_hSpeed = 0.0125f;
-    break;
+    case 2:
+      m_hSpeed = 0.0125f;
+      break;
 
-  case 3:
-    m_hSpeed = 0.1f;
-    break;
+    case 3:
+      m_hSpeed = 0.1f;
+      break;
 
-  case 4:
-    m_hSpeed = 0.2f;
-    break;
+    case 4:
+      m_hSpeed = 0.2f;
+      break;
 
-  case 0:
-  default:
-    m_hSpeed = 0.05f;
-    break;
+    case 0:
+    default:
+      m_hSpeed = 0.05f;
+      break;
   }
 }
 
@@ -346,18 +353,18 @@ void CVisualizationSpectrum::SetModeSetting(int settingValue)
 {
   switch (settingValue)
   {
-  case 1:
-    m_mode = 2; // D3DFILL_WIREFRAME;
-    break;
+    case 1:
+      m_mode = 2; // D3DFILL_WIREFRAME;
+      break;
 
-  case 2:
-    m_mode = 1; // D3DFILL_POINT;
-    break;
+    case 2:
+      m_mode = 1; // D3DFILL_POINT;
+      break;
 
-  case 0:
-  default:
-    m_mode = 3; // D3DFILL_SOLID;
-    break;
+    case 0:
+    default:
+      m_mode = 3; // D3DFILL_SOLID;
+      break;
   }
 }
 
@@ -365,7 +372,8 @@ void CVisualizationSpectrum::SetModeSetting(int settingValue)
 // Set a specific Setting value (called from XBMC)
 // !!! Add-on master function !!!
 //-----------------------------------------------------------------------------
-ADDON_STATUS CVisualizationSpectrum::SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue)
+ADDON_STATUS CVisualizationSpectrum::SetSetting(const std::string& settingName,
+                                                const kodi::addon::CSettingValue& settingValue)
 {
   if (settingName.empty() || settingValue.empty())
     return ADDON_STATUS_UNKNOWN;
@@ -394,15 +402,17 @@ ADDON_STATUS CVisualizationSpectrum::SetSetting(const std::string& settingName, 
   return ADDON_STATUS_UNKNOWN;
 }
 
-void CVisualizationSpectrum::draw_vertex(Vertex_t * pVertex, float x, float y, float z, XMFLOAT4 color)
+void CVisualizationSpectrum::draw_vertex(
+    Vertex_t* pVertex, float x, float y, float z, XMFLOAT4 color)
 {
   pVertex->col = XMFLOAT4(color);
   pVertex->pos = XMFLOAT3(x, y, z);
 }
 
-int CVisualizationSpectrum::draw_rectangle(Vertex_t * verts, float x1, float y1, float z1, float x2, float y2, float z2, XMFLOAT4 color)
+int CVisualizationSpectrum::draw_rectangle(
+    Vertex_t* verts, float x1, float y1, float z1, float x2, float y2, float z2, XMFLOAT4 color)
 {
-  if(y1 == y2)
+  if (y1 == y2)
   {
     draw_vertex(&verts[0], x1, y1, z1, color);
     draw_vertex(&verts[1], x2, y1, z1, color);
@@ -425,9 +435,10 @@ int CVisualizationSpectrum::draw_rectangle(Vertex_t * verts, float x1, float y1,
   return 6;
 }
 
-void CVisualizationSpectrum::draw_bar(float x_offset, float z_offset, float height, float red, float green, float blue)
+void CVisualizationSpectrum::draw_bar(
+    float x_offset, float z_offset, float height, float red, float green, float blue)
 {
-  Vertex_t  verts[NUM_VERTICIES];
+  Vertex_t verts[NUM_VERTICIES];
   int verts_idx = 0;
 
   float width = 0.1f;
@@ -439,23 +450,29 @@ void CVisualizationSpectrum::draw_bar(float x_offset, float z_offset, float heig
   if (1 != m_mode /*!= D3DFILL_POINT*/)
   {
     color = XMFLOAT4(red, green, blue, 1.0f);
-    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, height, z_offset, x_offset + width, height, z_offset + 0.1f, color);
+    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, height, z_offset, x_offset + width,
+                                height, z_offset + 0.1f, color);
   }
-  verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset, x_offset + width, 0.0f, z_offset + 0.1f, color);
+  verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset, x_offset + width, 0.0f,
+                              z_offset + 0.1f, color);
 
   if (1 != m_mode /*!= D3DFILL_POINT*/)
   {
     color = XMFLOAT4(0.5f * red, 0.5f * green, 0.5f * blue, 1.0f);
-    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset + 0.1f, x_offset + width, height, z_offset + 0.1f, color);
+    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset + 0.1f,
+                                x_offset + width, height, z_offset + 0.1f, color);
   }
-  verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset, x_offset + width, height, z_offset, color);
+  verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset, x_offset + width, height,
+                              z_offset, color);
 
   if (1 != m_mode /*!= D3DFILL_POINT*/)
   {
     color = XMFLOAT4(0.25f * red, 0.25f * green, 0.25f * blue, 1.0f);
-    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset , x_offset, height, z_offset + 0.1f, color);
+    verts_idx += draw_rectangle(&verts[verts_idx], x_offset, 0.0f, z_offset, x_offset, height,
+                                z_offset + 0.1f, color);
   }
-  verts_idx += draw_rectangle(&verts[verts_idx], x_offset + width, 0.0f, z_offset , x_offset + width, height, z_offset + 0.1f, color);
+  verts_idx += draw_rectangle(&verts[verts_idx], x_offset + width, 0.0f, z_offset, x_offset + width,
+                              height, z_offset + 0.1f, color);
 
   D3D11_MAPPED_SUBRESOURCE res;
   if (S_OK == m_context->Map(m_vBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &res))
@@ -464,59 +481,63 @@ void CVisualizationSpectrum::draw_bar(float x_offset, float z_offset, float heig
     m_context->Unmap(m_vBuffer, 0);
   }
 
-  m_context->IASetPrimitiveTopology(m_mode != 1 /*D3DFILL_POINT*/ ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST : D3D11_PRIMITIVE_TOPOLOGY_POINTLIST);
+  m_context->IASetPrimitiveTopology(
+      m_mode != 1 /*D3DFILL_POINT*/ ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST
+                                    : D3D11_PRIMITIVE_TOPOLOGY_POINTLIST);
   m_context->Draw(verts_idx, 0);
 }
 
 void CVisualizationSpectrum::draw_bars(void)
 {
-  int x,y;
+  int x, y;
   float x_offset, z_offset, r_base, b_base;
 
-  for(y = 0; y < 16; y++)
+  for (y = 0; y < 16; y++)
   {
     z_offset = -1.6f + ((15 - y) * 0.2f);
 
     b_base = y * (1.0f / 15);
     r_base = 1.0f - b_base;
 
-    for(x = 0; x < 16; x++)
+    for (x = 0; x < 16; x++)
     {
       x_offset = -1.6f + (x * 0.2f);
-      if (::fabs(cHeights[y][x]-heights[y][x])>m_hSpeed)
+      if (::fabs(cHeights[y][x] - heights[y][x]) > m_hSpeed)
       {
-        if (cHeights[y][x]<heights[y][x])
+        if (cHeights[y][x] < heights[y][x])
           cHeights[y][x] += m_hSpeed;
         else
           cHeights[y][x] -= m_hSpeed;
       }
-      draw_bar(x_offset, z_offset,
-               cHeights[y][x], r_base - (x * (r_base / 15.0f)),
-               x * (1.0f / 15), b_base);
+      draw_bar(x_offset, z_offset, cHeights[y][x], r_base - (x * (r_base / 15.0f)), x * (1.0f / 15),
+               b_base);
     }
   }
 }
 
 bool CVisualizationSpectrum::init_renderer_objs()
 {
-  if (S_OK != m_device->CreateVertexShader(DefaultVertexShaderCode, sizeof(DefaultVertexShaderCode), nullptr, &m_vShader))
+  if (S_OK != m_device->CreateVertexShader(DefaultVertexShaderCode, sizeof(DefaultVertexShaderCode),
+                                           nullptr, &m_vShader))
     return false;
 
   // Create input layout
-  D3D11_INPUT_ELEMENT_DESC layout[] =
-  {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT,    0,  0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
-  if (S_OK != m_device->CreateInputLayout(layout, ARRAYSIZE(layout), DefaultVertexShaderCode, sizeof(DefaultVertexShaderCode), &m_inputLayout))
+  if (S_OK != m_device->CreateInputLayout(layout, ARRAYSIZE(layout), DefaultVertexShaderCode,
+                                          sizeof(DefaultVertexShaderCode), &m_inputLayout))
     return false;
 
   // Create pixel shader
-  if (S_OK != m_device->CreatePixelShader(DefaultPixelShaderCode, sizeof(DefaultPixelShaderCode), nullptr, &m_pShader))
+  if (S_OK != m_device->CreatePixelShader(DefaultPixelShaderCode, sizeof(DefaultPixelShaderCode),
+                                          nullptr, &m_pShader))
     return false;
 
   // create buffers
-  CD3D11_BUFFER_DESC desc(sizeof(Vertex_t) * NUM_VERTICIES, D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
+  CD3D11_BUFFER_DESC desc(sizeof(Vertex_t) * NUM_VERTICIES, D3D11_BIND_VERTEX_BUFFER,
+                          D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   if (S_OK != m_device->CreateBuffer(&desc, NULL, &m_vBuffer))
     return false;
 
@@ -527,21 +548,22 @@ bool CVisualizationSpectrum::init_renderer_objs()
 
   cbViewProj cViewProj;
   XMStoreFloat4x4(&cViewProj.view, XMMatrixTranspose(XMMatrixIdentity()));
-  XMStoreFloat4x4(&cViewProj.proj, XMMatrixTranspose(XMMatrixPerspectiveOffCenterLH(-1.0f, 1.0f, -1.0f, 1.0f, 1.5f, 10.0f)));
+  XMStoreFloat4x4(&cViewProj.proj, XMMatrixTranspose(XMMatrixPerspectiveOffCenterLH(
+                                       -1.0f, 1.0f, -1.0f, 1.0f, 1.5f, 10.0f)));
 
   desc.ByteWidth = sizeof(cbViewProj);
   desc.Usage = D3D11_USAGE_DEFAULT;
   desc.CPUAccessFlags = 0;
-  D3D11_SUBRESOURCE_DATA initData = { 0 };
+  D3D11_SUBRESOURCE_DATA initData = {0};
   initData.pSysMem = &cViewProj;
   if (S_OK != m_device->CreateBuffer(&desc, &initData, &m_cViewProj))
     return false;
 
   // create blend state
-  D3D11_BLEND_DESC blendState = { 0 };
+  D3D11_BLEND_DESC blendState = {0};
   ZeroMemory(&blendState, sizeof(D3D11_BLEND_DESC));
   blendState.RenderTarget[0].BlendEnable = true;
-  blendState.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE; 
+  blendState.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
   blendState.RenderTarget[0].DestBlend = D3D11_BLEND_ZERO;
   blendState.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
   blendState.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -64,14 +64,18 @@ private:
   void SetSpeedSetting(int settingValue);
   void SetModeSetting(int settingValue);
 
-  GLfloat m_heights[16][16];
-  GLfloat m_cHeights[16][16];
+  GLfloat m_heights[16][16] = {0};
+  GLfloat m_cHeights[16][16] = {0};
   GLfloat m_scale;
-  GLenum m_mode;
-  float m_y_angle, m_y_speed, m_y_fixedAngle;
-  float m_x_angle, m_x_speed;
-  float m_z_angle, m_z_speed;
-  float m_hSpeed;
+  GLenum m_mode{GL_TRIANGLES};
+  float m_y_angle{45.0f};
+  float m_y_speed{0.5f};
+  float m_y_fixedAngle{0.0f};
+  float m_x_angle{20.0f};
+  float m_x_speed{0.0f};
+  float m_z_angle{0.0f};
+  float m_z_speed{0.0f};
+  float m_hSpeed{0.05f};
 
   void draw_bar(
       GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue);
@@ -80,7 +84,7 @@ private:
   // Shader related data
   glm::mat4 m_projMat;
   glm::mat4 m_modelMat;
-  GLfloat m_pointSize = 0.0f;
+  GLfloat m_pointSize{0.0f};
   std::array<glm::vec3, 48> m_vertex_buffer_data;
   std::array<glm::vec3, 48> m_color_buffer_data;
 
@@ -88,31 +92,18 @@ private:
   GLuint m_vertexVBO[2] = {0};
 #endif
 
-  GLint m_uProjMatrix = -1;
-  GLint m_uModelMatrix = -1;
-  GLint m_uPointSize = -1;
-  GLint m_hPos = -1;
-  GLint m_hCol = -1;
+  GLint m_uProjMatrix{-1};
+  GLint m_uModelMatrix{-1};
+  GLint m_uPointSize{-1};
+  GLint m_hPos{-1};
+  GLint m_hCol{-1};
 
-  bool m_startOK = false;
+  bool m_startOK{false};
 };
 
 CVisualizationSpectrum::CVisualizationSpectrum()
-  : m_mode(GL_TRIANGLES),
-    m_y_angle(45.0f),
-    m_y_speed(0.5f),
-    m_x_angle(20.0f),
-    m_x_speed(0.0f),
-    m_z_angle(0.0f),
-    m_z_speed(0.0f),
-    m_hSpeed(0.05f)
 {
   m_scale = 1.0 / log(256.0);
-
-  SetBarHeightSetting(kodi::addon::GetSettingInt("bar_height"));
-  SetSpeedSetting(kodi::addon::GetSettingInt("speed"));
-  SetModeSetting(kodi::addon::GetSettingInt("mode"));
-  m_y_fixedAngle = kodi::addon::GetSettingInt("rotation_angle");
 }
 
 bool CVisualizationSpectrum::Start(int channels,
@@ -125,6 +116,11 @@ bool CVisualizationSpectrum::Start(int channels,
   (void)bitsPerSample;
   (void)songName;
 
+  SetBarHeightSetting(kodi::addon::GetSettingInt("bar_height"));
+  SetSpeedSetting(kodi::addon::GetSettingInt("speed"));
+  SetModeSetting(kodi::addon::GetSettingInt("mode"));
+  m_y_fixedAngle = kodi::addon::GetSettingInt("rotation_angle");
+
   std::string fraqShader =
       kodi::addon::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/frag.glsl");
   std::string vertShader =
@@ -134,24 +130,6 @@ bool CVisualizationSpectrum::Start(int channels,
     kodi::Log(ADDON_LOG_ERROR, "Failed to create or compile shader");
     return false;
   }
-
-  int x, y;
-
-  for (x = 0; x < 16; x++)
-  {
-    for (y = 0; y < 16; y++)
-    {
-      m_heights[y][x] = 0.0f;
-      m_cHeights[y][x] = 0.0f;
-    }
-  }
-
-  m_x_speed = 0.0f;
-  m_y_speed = 0.5f;
-  m_z_speed = 0.0f;
-  m_x_angle = 20.0f;
-  m_y_angle = 45.0f;
-  m_z_angle = 0.0f;
 
   m_projMat = glm::frustum(-1.0f, 1.0f, -1.0f, 1.0f, 1.5f, 10.0f);
 

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -21,17 +21,15 @@
 
 #define __STDC_LIMIT_MACROS
 
+#include <cstddef>
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #include <kodi/addon-instance/Visualization.h>
 #include <kodi/gui/gl/GL.h>
 #include <kodi/gui/gl/Shader.h>
-
-#include <string.h>
 #include <math.h>
 #include <stdint.h>
-#include <cstddef>
-
-#include <glm/glm.hpp>
-#include <glm/gtc/type_ptr.hpp>
+#include <string.h>
 
 #ifndef M_PI
 #define M_PI 3.141592654f
@@ -39,20 +37,23 @@
 
 #define NUM_BANDS 16
 
-class ATTR_DLL_LOCAL CVisualizationSpectrum
-  : public kodi::addon::CAddonBase,
-    public kodi::addon::CInstanceVisualization,
-    public kodi::gui::gl::CShaderProgram
+class ATTR_DLL_LOCAL CVisualizationSpectrum : public kodi::addon::CAddonBase,
+                                              public kodi::addon::CInstanceVisualization,
+                                              public kodi::gui::gl::CShaderProgram
 {
 public:
   CVisualizationSpectrum();
   ~CVisualizationSpectrum() override = default;
 
-  bool Start(int channels, int samplesPerSec, int bitsPerSample, const std::string& songName) override;
+  bool Start(int channels,
+             int samplesPerSec,
+             int bitsPerSample,
+             const std::string& songName) override;
   void Stop() override;
   void Render() override;
   void AudioData(const float* audioData, size_t audioDataLength) override;
-  ADDON_STATUS SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue) override;
+  ADDON_STATUS SetSetting(const std::string& settingName,
+                          const kodi::addon::CSettingValue& settingValue) override;
 
   void OnCompiledAndLinked() override;
   bool OnEnabled() override;
@@ -71,7 +72,8 @@ private:
   float m_z_angle, m_z_speed;
   float m_hSpeed;
 
-  void draw_bar(GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue);
+  void draw_bar(
+      GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue);
   void draw_bars(void);
 
   // Shader related data
@@ -115,15 +117,20 @@ CVisualizationSpectrum::CVisualizationSpectrum()
   m_color_buffer_data.resize(48);
 }
 
-bool CVisualizationSpectrum::Start(int channels, int samplesPerSec, int bitsPerSample, const std::string& songName)
+bool CVisualizationSpectrum::Start(int channels,
+                                   int samplesPerSec,
+                                   int bitsPerSample,
+                                   const std::string& songName)
 {
   (void)channels;
   (void)samplesPerSec;
   (void)bitsPerSample;
   (void)songName;
 
-  std::string fraqShader = kodi::addon::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/frag.glsl");
-  std::string vertShader = kodi::addon::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/vert.glsl");
+  std::string fraqShader =
+      kodi::addon::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/frag.glsl");
+  std::string vertShader =
+      kodi::addon::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/vert.glsl");
   if (!LoadShaderFiles(vertShader, fraqShader) || !CompileAndLink())
   {
     kodi::Log(ADDON_LOG_ERROR, "Failed to create or compile shader");
@@ -132,9 +139,9 @@ bool CVisualizationSpectrum::Start(int channels, int samplesPerSec, int bitsPerS
 
   int x, y;
 
-  for(x = 0; x < 16; x++)
+  for (x = 0; x < 16; x++)
   {
-    for(y = 0; y < 16; y++)
+    for (y = 0; y < 16; y++)
     {
       m_heights[y][x] = 0.0f;
       m_cHeights[y][x] = 0.0f;
@@ -183,11 +190,11 @@ void CVisualizationSpectrum::Render()
 
 #ifdef HAS_GL
   glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO[0]);
-  glVertexAttribPointer(m_hPos, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*3, nullptr);
+  glVertexAttribPointer(m_hPos, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat) * 3, nullptr);
   glEnableVertexAttribArray(m_hPos);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO[1]);
-  glVertexAttribPointer(m_hCol, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*3, nullptr);
+  glVertexAttribPointer(m_hCol, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat) * 3, nullptr);
   glEnableVertexAttribArray(m_hCol);
 #else
   // 1rst attribute buffer : vertices
@@ -210,13 +217,13 @@ void CVisualizationSpectrum::Render()
   glClear(GL_DEPTH_BUFFER_BIT);
 
   m_x_angle += m_x_speed;
-  if(m_x_angle >= 360.0f)
+  if (m_x_angle >= 360.0f)
     m_x_angle -= 360.0f;
 
   if (m_y_fixedAngle < 0.0f)
   {
     m_y_angle += m_y_speed;
-    if(m_y_angle >= 360.0f)
+    if (m_y_angle >= 360.0f)
       m_y_angle -= 360.0f;
   }
   else
@@ -225,7 +232,7 @@ void CVisualizationSpectrum::Render()
   }
 
   m_z_angle += m_z_speed;
-  if(m_z_angle >= 360.0f)
+  if (m_z_angle >= 360.0f)
     m_z_angle -= 360.0f;
 
   m_modelMat = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, -0.5f, -5.0f));
@@ -269,70 +276,68 @@ bool CVisualizationSpectrum::OnEnabled()
   return true;
 }
 
-void CVisualizationSpectrum::draw_bar(GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue )
+void CVisualizationSpectrum::draw_bar(
+    GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue)
 {
   GLfloat width = 0.1f;
-  m_vertex_buffer_data =
-  {
-    // Bottom
-    { x_offset + width, 0.0f,   z_offset + width },
-    { x_offset,         0.0f,   z_offset },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset + width, 0.0f,   z_offset + width },
-    { x_offset,         0.0f,   z_offset + width },
-    { x_offset,         0.0f,   z_offset },
+  m_vertex_buffer_data = {// Bottom
+                          {x_offset + width, 0.0f, z_offset + width},
+                          {x_offset, 0.0f, z_offset},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset + width, 0.0f, z_offset + width},
+                          {x_offset, 0.0f, z_offset + width},
+                          {x_offset, 0.0f, z_offset},
 
-    { x_offset,         0.0f,   z_offset + width },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset + width, 0.0f,   z_offset + width },
-    { x_offset,         0.0f,   z_offset + width },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset,         0.0f,   z_offset },
+                          {x_offset, 0.0f, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset + width, 0.0f, z_offset + width},
+                          {x_offset, 0.0f, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset, 0.0f, z_offset},
 
-    // Side
-    { x_offset,         0.0f,   z_offset },
-    { x_offset,         0.0f,   z_offset + width },
-    { x_offset,         height, z_offset + width },
-    { x_offset,         0.0f,   z_offset },
-    { x_offset,         height, z_offset + width },
-    { x_offset,         height, z_offset },
+                          // Side
+                          {x_offset, 0.0f, z_offset},
+                          {x_offset, 0.0f, z_offset + width},
+                          {x_offset, height, z_offset + width},
+                          {x_offset, 0.0f, z_offset},
+                          {x_offset, height, z_offset + width},
+                          {x_offset, height, z_offset},
 
-    { x_offset + width, height, z_offset },
-    { x_offset,         0.0f,   z_offset },
-    { x_offset,         height, z_offset },
-    { x_offset + width, height, z_offset },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset,         0.0f,   z_offset },
+                          {x_offset + width, height, z_offset},
+                          {x_offset, 0.0f, z_offset},
+                          {x_offset, height, z_offset},
+                          {x_offset + width, height, z_offset},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset, 0.0f, z_offset},
 
-    { x_offset,         height, z_offset + width },
-    { x_offset,         0.0f,   z_offset + width },
-    { x_offset + width, 0.0f,   z_offset + width },
-    { x_offset + width, height, z_offset + width },
-    { x_offset,         height, z_offset + width },
-    { x_offset + width, 0.0f,   z_offset + width },
+                          {x_offset, height, z_offset + width},
+                          {x_offset, 0.0f, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset + width},
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset, height, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset + width},
 
-    { x_offset + width, height, z_offset + width },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset + width, height, z_offset },
-    { x_offset + width, 0.0f,   z_offset },
-    { x_offset + width, height, z_offset + width },
-    { x_offset + width, 0.0f,   z_offset + width },
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset + width, height, z_offset},
+                          {x_offset + width, 0.0f, z_offset},
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset + width, 0.0f, z_offset + width},
 
-    // Top
-    { x_offset + width, height, z_offset + width },
-    { x_offset + width, height, z_offset },
-    { x_offset,         height, z_offset },
-    { x_offset + width, height, z_offset + width },
-    { x_offset,         height, z_offset },
-    { x_offset,         height, z_offset + width },
+                          // Top
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset + width, height, z_offset},
+                          {x_offset, height, z_offset},
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset, height, z_offset},
+                          {x_offset, height, z_offset + width},
 
-    { x_offset,         height, z_offset + width },
-    { x_offset + width, height, z_offset },
-    { x_offset,         height, z_offset },
-    { x_offset + width, height, z_offset },
-    { x_offset + width, height, z_offset + width },
-    { x_offset,         height, z_offset + width }
-  };
+                          {x_offset, height, z_offset + width},
+                          {x_offset + width, height, z_offset},
+                          {x_offset, height, z_offset},
+                          {x_offset + width, height, z_offset},
+                          {x_offset + width, height, z_offset + width},
+                          {x_offset, height, z_offset + width}};
 
   float sideMlpy1, sideMlpy2, sideMlpy3, sideMlpy4;
   if (m_mode == GL_TRIANGLES)
@@ -348,75 +353,79 @@ void CVisualizationSpectrum::draw_bar(GLfloat x_offset, GLfloat z_offset, GLfloa
   }
 
   // One color for each vertex. They were generated randomly.
-  m_color_buffer_data =
-  {
-    // Bottom
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
+  m_color_buffer_data = {
+      // Bottom
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
 
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
 
-    // Side
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
-    { red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1 },
+      // Side
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
+      {red * sideMlpy1, green * sideMlpy1, blue * sideMlpy1},
 
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
-    { red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2 },
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
+      {red * sideMlpy2, green * sideMlpy2, blue * sideMlpy2},
 
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
-    { red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3 },
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
+      {red * sideMlpy3, green * sideMlpy3, blue * sideMlpy3},
 
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
-    { red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4 },
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
+      {red * sideMlpy4, green * sideMlpy4, blue * sideMlpy4},
 
-    // Top
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
+      // Top
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
 
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
-    { red, green, blue },
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
+      {red, green, blue},
   };
 
 #ifdef HAS_GL
   glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO[0]);
-  glBufferData(GL_ARRAY_BUFFER, m_vertex_buffer_data.size()*sizeof(glm::vec3), &m_vertex_buffer_data[0], GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, m_vertex_buffer_data.size() * sizeof(glm::vec3),
+               &m_vertex_buffer_data[0], GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO[1]);
-  glBufferData(GL_ARRAY_BUFFER, m_color_buffer_data.size()*sizeof(glm::vec3), &m_color_buffer_data[0], GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, m_color_buffer_data.size() * sizeof(glm::vec3),
+               &m_color_buffer_data[0], GL_STATIC_DRAW);
 #endif
-  glDrawArrays(m_mode, 0, m_vertex_buffer_data.size()); /* 12*3 indices starting at 0 -> 12 triangles + 4*3 to have on lines show correct */
+  glDrawArrays(
+      m_mode, 0,
+      m_vertex_buffer_data
+          .size()); /* 12*3 indices starting at 0 -> 12 triangles + 4*3 to have on lines show correct */
 }
 
 void CVisualizationSpectrum::draw_bars(void)
@@ -424,58 +433,59 @@ void CVisualizationSpectrum::draw_bars(void)
   int x, y;
   GLfloat x_offset, z_offset, r_base, b_base;
 
-  for(y = 0; y < 16; y++)
+  for (y = 0; y < 16; y++)
   {
     z_offset = -1.6 + ((15 - y) * 0.2);
 
     b_base = y * (1.0 / 15);
     r_base = 1.0 - b_base;
 
-    for(x = 0; x < 16; x++)
+    for (x = 0; x < 16; x++)
     {
       x_offset = -1.6 + ((float)x * 0.2);
-      if (::fabs(m_cHeights[y][x]-m_heights[y][x])>m_hSpeed)
+      if (::fabs(m_cHeights[y][x] - m_heights[y][x]) > m_hSpeed)
       {
-        if (m_cHeights[y][x]<m_heights[y][x])
+        if (m_cHeights[y][x] < m_heights[y][x])
           m_cHeights[y][x] += m_hSpeed;
         else
           m_cHeights[y][x] -= m_hSpeed;
       }
-      draw_bar(x_offset, z_offset, m_cHeights[y][x], r_base - (float(x) * (r_base / 15.0)), (float)x * (1.0 / 15), b_base);
+      draw_bar(x_offset, z_offset, m_cHeights[y][x], r_base - (float(x) * (r_base / 15.0)),
+               (float)x * (1.0 / 15), b_base);
     }
   }
 }
 
 void CVisualizationSpectrum::AudioData(const float* pAudioData, size_t iAudioDataLength)
 {
-  int i,c;
-  int y=0;
+  int i, c;
+  int y = 0;
   GLfloat val;
 
   int xscale[] = {0, 1, 2, 3, 5, 7, 10, 14, 20, 28, 40, 54, 74, 101, 137, 187, 255};
 
-  for(y = 15; y > 0; y--)
+  for (y = 15; y > 0; y--)
   {
-    for(i = 0; i < 16; i++)
+    for (i = 0; i < 16; i++)
     {
       m_heights[y][i] = m_heights[y - 1][i];
     }
   }
 
-  for(i = 0; i < NUM_BANDS; i++)
+  for (i = 0; i < NUM_BANDS; i++)
   {
-    for(c = xscale[i], y = 0; c < xscale[i + 1]; c++)
+    for (c = xscale[i], y = 0; c < xscale[i + 1]; c++)
     {
-      if (c<iAudioDataLength)
+      if (c < iAudioDataLength)
       {
-        if((int)(pAudioData[c] * (INT16_MAX)) > y)
+        if ((int)(pAudioData[c] * (INT16_MAX)) > y)
           y = (int)(pAudioData[c] * (INT16_MAX));
       }
       else
         continue;
     }
     y >>= 7;
-    if(y > 0)
+    if (y > 0)
       val = (logf(y) * m_scale);
     else
       val = 0;
@@ -487,26 +497,26 @@ void CVisualizationSpectrum::SetBarHeightSetting(int settingValue)
 {
   switch (settingValue)
   {
-  case 1://standard
-    m_scale = 1.f / log(256.f);
-    break;
+    case 1: //standard
+      m_scale = 1.f / log(256.f);
+      break;
 
-  case 2://big
-    m_scale = 2.f / log(256.f);
-    break;
+    case 2: //big
+      m_scale = 2.f / log(256.f);
+      break;
 
-  case 3://real big
-    m_scale = 3.f / log(256.f);
-    break;
+    case 3: //real big
+      m_scale = 3.f / log(256.f);
+      break;
 
-  case 4://unused
-    m_scale = 0.33f / log(256.f);
-    break;
+    case 4: //unused
+      m_scale = 0.33f / log(256.f);
+      break;
 
-  case 0://small
-  default:
-    m_scale = 0.5f / log(256.f);
-    break;
+    case 0: //small
+    default:
+      m_scale = 0.5f / log(256.f);
+      break;
   }
 }
 
@@ -514,26 +524,26 @@ void CVisualizationSpectrum::SetSpeedSetting(int settingValue)
 {
   switch (settingValue)
   {
-  case 1:
-    m_hSpeed = 0.025f;
-    break;
+    case 1:
+      m_hSpeed = 0.025f;
+      break;
 
-  case 2:
-    m_hSpeed = 0.0125f;
-    break;
+    case 2:
+      m_hSpeed = 0.0125f;
+      break;
 
-  case 3:
-    m_hSpeed = 0.1f;
-    break;
+    case 3:
+      m_hSpeed = 0.1f;
+      break;
 
-  case 4:
-    m_hSpeed = 0.2f;
-    break;
+    case 4:
+      m_hSpeed = 0.2f;
+      break;
 
-  case 0:
-  default:
-    m_hSpeed = 0.05f;
-    break;
+    case 0:
+    default:
+      m_hSpeed = 0.05f;
+      break;
   }
 }
 
@@ -563,7 +573,8 @@ void CVisualizationSpectrum::SetModeSetting(int settingValue)
 // Set a specific Setting value (called from Kodi)
 // !!! Add-on master function !!!
 //-----------------------------------------------------------------------------
-ADDON_STATUS CVisualizationSpectrum::SetSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue)
+ADDON_STATUS CVisualizationSpectrum::SetSetting(const std::string& settingName,
+                                                const kodi::addon::CSettingValue& settingValue)
 {
   if (settingName.empty() || settingValue.empty())
     return ADDON_STATUS_UNKNOWN;

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1998-2000 Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
- *  Copyright (C) 2005-2022 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2026 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -21,6 +21,7 @@
 
 #define __STDC_LIMIT_MACROS
 
+#include <array>
 #include <cstddef>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
@@ -80,8 +81,8 @@ private:
   glm::mat4 m_projMat;
   glm::mat4 m_modelMat;
   GLfloat m_pointSize = 0.0f;
-  std::vector<glm::vec3> m_vertex_buffer_data;
-  std::vector<glm::vec3> m_color_buffer_data;
+  std::array<glm::vec3, 48> m_vertex_buffer_data;
+  std::array<glm::vec3, 48> m_color_buffer_data;
 
 #ifdef HAS_GL
   GLuint m_vertexVBO[2] = {0};
@@ -112,9 +113,6 @@ CVisualizationSpectrum::CVisualizationSpectrum()
   SetSpeedSetting(kodi::addon::GetSettingInt("speed"));
   SetModeSetting(kodi::addon::GetSettingInt("mode"));
   m_y_fixedAngle = kodi::addon::GetSettingInt("rotation_angle");
-
-  m_vertex_buffer_data.resize(48);
-  m_color_buffer_data.resize(48);
 }
 
 bool CVisualizationSpectrum::Start(int channels,
@@ -280,64 +278,66 @@ void CVisualizationSpectrum::draw_bar(
     GLfloat x_offset, GLfloat z_offset, GLfloat height, GLfloat red, GLfloat green, GLfloat blue)
 {
   GLfloat width = 0.1f;
-  m_vertex_buffer_data = {// Bottom
-                          {x_offset + width, 0.0f, z_offset + width},
-                          {x_offset, 0.0f, z_offset},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset + width, 0.0f, z_offset + width},
-                          {x_offset, 0.0f, z_offset + width},
-                          {x_offset, 0.0f, z_offset},
+  m_vertex_buffer_data = {{
+      // Bottom
+      {x_offset + width, 0.0f, z_offset + width},
+      {x_offset, 0.0f, z_offset},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset + width, 0.0f, z_offset + width},
+      {x_offset, 0.0f, z_offset + width},
+      {x_offset, 0.0f, z_offset},
 
-                          {x_offset, 0.0f, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset + width, 0.0f, z_offset + width},
-                          {x_offset, 0.0f, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset, 0.0f, z_offset},
+      {x_offset, 0.0f, z_offset + width},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset + width, 0.0f, z_offset + width},
+      {x_offset, 0.0f, z_offset + width},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset, 0.0f, z_offset},
 
-                          // Side
-                          {x_offset, 0.0f, z_offset},
-                          {x_offset, 0.0f, z_offset + width},
-                          {x_offset, height, z_offset + width},
-                          {x_offset, 0.0f, z_offset},
-                          {x_offset, height, z_offset + width},
-                          {x_offset, height, z_offset},
+      // Side
+      {x_offset, 0.0f, z_offset},
+      {x_offset, 0.0f, z_offset + width},
+      {x_offset, height, z_offset + width},
+      {x_offset, 0.0f, z_offset},
+      {x_offset, height, z_offset + width},
+      {x_offset, height, z_offset},
 
-                          {x_offset + width, height, z_offset},
-                          {x_offset, 0.0f, z_offset},
-                          {x_offset, height, z_offset},
-                          {x_offset + width, height, z_offset},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset, 0.0f, z_offset},
+      {x_offset + width, height, z_offset},
+      {x_offset, 0.0f, z_offset},
+      {x_offset, height, z_offset},
+      {x_offset + width, height, z_offset},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset, 0.0f, z_offset},
 
-                          {x_offset, height, z_offset + width},
-                          {x_offset, 0.0f, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset + width},
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset, height, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset + width},
+      {x_offset, height, z_offset + width},
+      {x_offset, 0.0f, z_offset + width},
+      {x_offset + width, 0.0f, z_offset + width},
+      {x_offset + width, height, z_offset + width},
+      {x_offset, height, z_offset + width},
+      {x_offset + width, 0.0f, z_offset + width},
 
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset + width, height, z_offset},
-                          {x_offset + width, 0.0f, z_offset},
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset + width, 0.0f, z_offset + width},
+      {x_offset + width, height, z_offset + width},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset + width, height, z_offset},
+      {x_offset + width, 0.0f, z_offset},
+      {x_offset + width, height, z_offset + width},
+      {x_offset + width, 0.0f, z_offset + width},
 
-                          // Top
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset + width, height, z_offset},
-                          {x_offset, height, z_offset},
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset, height, z_offset},
-                          {x_offset, height, z_offset + width},
+      // Top
+      {x_offset + width, height, z_offset + width},
+      {x_offset + width, height, z_offset},
+      {x_offset, height, z_offset},
+      {x_offset + width, height, z_offset + width},
+      {x_offset, height, z_offset},
+      {x_offset, height, z_offset + width},
 
-                          {x_offset, height, z_offset + width},
-                          {x_offset + width, height, z_offset},
-                          {x_offset, height, z_offset},
-                          {x_offset + width, height, z_offset},
-                          {x_offset + width, height, z_offset + width},
-                          {x_offset, height, z_offset + width}};
+      {x_offset, height, z_offset + width},
+      {x_offset + width, height, z_offset},
+      {x_offset, height, z_offset},
+      {x_offset + width, height, z_offset},
+      {x_offset + width, height, z_offset + width},
+      {x_offset, height, z_offset + width},
+  }};
 
   float sideMlpy1, sideMlpy2, sideMlpy3, sideMlpy4;
   if (m_mode == GL_TRIANGLES)
@@ -353,7 +353,7 @@ void CVisualizationSpectrum::draw_bar(
   }
 
   // One color for each vertex. They were generated randomly.
-  m_color_buffer_data = {
+  m_color_buffer_data = {{
       // Bottom
       {red, green, blue},
       {red, green, blue},
@@ -412,7 +412,7 @@ void CVisualizationSpectrum::draw_bar(
       {red, green, blue},
       {red, green, blue},
       {red, green, blue},
-  };
+  }};
 
 #ifdef HAS_GL
   glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO[0]);

--- a/src/opengl_spectrum.cpp
+++ b/src/opengl_spectrum.cpp
@@ -46,11 +46,8 @@ public:
   CVisualizationSpectrum();
   ~CVisualizationSpectrum() override = default;
 
-  bool Start(int channels,
-             int samplesPerSec,
-             int bitsPerSample,
-             const std::string& songName) override;
-  void Stop() override;
+  bool Init() override;
+  void DeInit() override;
   void Render() override;
   void AudioData(const float* audioData, size_t audioDataLength) override;
   ADDON_STATUS SetSetting(const std::string& settingName,
@@ -106,16 +103,8 @@ CVisualizationSpectrum::CVisualizationSpectrum()
   m_scale = 1.0 / log(256.0);
 }
 
-bool CVisualizationSpectrum::Start(int channels,
-                                   int samplesPerSec,
-                                   int bitsPerSample,
-                                   const std::string& songName)
+bool CVisualizationSpectrum::Init()
 {
-  (void)channels;
-  (void)samplesPerSec;
-  (void)bitsPerSample;
-  (void)songName;
-
   SetBarHeightSetting(kodi::addon::GetSettingInt("bar_height"));
   SetSpeedSetting(kodi::addon::GetSettingInt("speed"));
   SetModeSetting(kodi::addon::GetSettingInt("mode"));
@@ -141,7 +130,7 @@ bool CVisualizationSpectrum::Start(int channels,
   return true;
 }
 
-void CVisualizationSpectrum::Stop()
+void CVisualizationSpectrum::DeInit()
 {
   if (!m_startOK)
     return;

--- a/visualization.spectrum/addon.xml.in
+++ b/visualization.spectrum/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.spectrum"
-  version="22.0.3"
+  version="22.1.0"
   name="Spectrum"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Add-on update related to Kodi API change defined on https://github.com/xbmc/xbmc/pull/28278

Further done some code cleanups as some parts was a bit strange and wrong.

Runtime tests on Windows and Linux.
- Linux OK
- Windows Bad!

## **WARNING:**
**The fact that DirectX no longer works has nothing to do with the changes made here.**

**For some reason the screen stays black here under Windows 11 and Kodi 22 Piers.**

I had already brought Angle in as a test, and there was a display, but it didn't appear correctly.

So it's a major undertaking to get this working correctly again under Windows!

Partly relates to this issue https://github.com/xbmc/visualization.spectrum/issues/31 too, only Windows now black and the picture visible there match the screen brought by use of Angle during tests.

I will try to use the latest code from an open pull request on the original for us in the near future.
See here where a newer GL support planned to come in: 
- https://github.com/audacious-media-player/audacious-plugins/pull/183 (in the original it is still the ancient version without shader supprt).

***The only question now is should we remove the add-on from Windows support immediately or leave it there, maybe it will work for others?***